### PR TITLE
used the right enum after the typo change

### DIFF
--- a/src/EA.Weee.Web/Areas/AatfReturn/Views/ObligatedReceived/Index.cshtml
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Views/ObligatedReceived/Index.cshtml
@@ -26,7 +26,7 @@
         <div class="govuk-table govuk-!-margin-bottom-0">
             <div class="govuk-grid-column-one-half">&nbsp;</div>
             <div class="govuk-grid-column-one-half govuk-body govuk-!-font-size-19" style="padding-left: 1em">
-                @Html.RouteLink("Use copy and paste to populate the table", AatfRedirect.AatfSelectedRoute, new { returnId = Model.ReturnId, aatfId = Model.AatfId, schemeId = Model.SchemeId, obligatedType = ObligatedType.Recieved, action = "Index", controller = "ObligatedValuesCopyPaste" }, null)
+                @Html.RouteLink("Use copy and paste to populate the table", AatfRedirect.AatfSelectedRoute, new { returnId = Model.ReturnId, aatfId = Model.AatfId, schemeId = Model.SchemeId, obligatedType = ObligatedType.Received, action = "Index", controller = "ObligatedValuesCopyPaste" }, null)
             </div>
         </div>
 


### PR DESCRIPTION
Realised I hadn't changed the type where it was used in the html. 