### PR TITLE
Added some logic so that the error message focuses when clicked

### DIFF
--- a/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/SelectReportOptionsControllerTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/SelectReportOptionsControllerTests.cs
@@ -212,6 +212,19 @@
             }
         }
 
+        [Fact]
+        public async void NonObligatedWeeSelected_NoDcfOptionSelected_ViewModelShouldHaveDcfError()
+        {
+            SelectReportOptionsViewModel viewModel = new SelectReportOptionsViewModel();
+            controller.ModelState.AddModelError("DcfSelectedValue-0", "You must tell us whether any of the non-obligated WEEE was retained by a DCF");
+
+            var result = await controller.Index(viewModel) as ViewResult;
+
+            var outputModel = result.Model as SelectReportOptionsViewModel;
+
+            Assert.Equal(true, outputModel.HasDcfError);
+        }
+
         private static SelectReportOptionsViewModel CreateSubmittedViewModel()
         {
             var model = new SelectReportOptionsViewModel();

--- a/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/SelectReportOptionsControllerTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/SelectReportOptionsControllerTests.cs
@@ -225,6 +225,19 @@
             Assert.Equal(true, outputModel.HasDcfError);
         }
 
+        [Fact]
+        public async void NonObligatedWeeNotSelected_ViewModelShouldNotHaveDcfError()
+        {
+            SelectReportOptionsViewModel viewModel = new SelectReportOptionsViewModel();
+            controller.ModelState.AddModelError("error", "error");
+
+            var result = await controller.Index(viewModel) as ViewResult;
+
+            var outputModel = result.Model as SelectReportOptionsViewModel;
+
+            Assert.Equal(false, outputModel.HasDcfError);
+        }
+
         private static SelectReportOptionsViewModel CreateSubmittedViewModel()
         {
             var model = new SelectReportOptionsViewModel();

--- a/src/EA.Weee.Web/Areas/AATFReturn/Controllers/SelectReportOptionsController.cs
+++ b/src/EA.Weee.Web/Areas/AATFReturn/Controllers/SelectReportOptionsController.cs
@@ -92,6 +92,8 @@
 
             await SetBreadcrumb(viewModel.OrganisationId, BreadCrumbConstant.AatfReturn);
 
+            viewModel.HasDcfError = GetDcfModelStateError();
+
             return View(viewModel);
         }
 
@@ -111,6 +113,13 @@
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
             breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+        }
+
+        private bool GetDcfModelStateError()
+        {
+            IEnumerable<ModelError> allErrors = ModelState.Values.SelectMany(v => v.Errors);
+
+            return allErrors != null && allErrors.Count(p => p.ErrorMessage == "You must tell us whether any of the non-obligated WEEE was retained by a DCF") > 0;
         }
     }
 }

--- a/src/EA.Weee.Web/Areas/AATFReturn/ViewModels/SelectReportOptionsViewModel.cs
+++ b/src/EA.Weee.Web/Areas/AATFReturn/ViewModels/SelectReportOptionsViewModel.cs
@@ -46,6 +46,8 @@
 
         public IList<string> DcfPossibleValues => new List<string> { "Yes", "No" };
 
+        public bool HasDcfError { get; set; }
+
         public DateTime QuarterWindowStartDate { get; set; }
 
         public DateTime QuarterWindowEndDate { get; set; }

--- a/src/EA.Weee.Web/Areas/AATFReturn/ViewModels/Validation/SelectReportOptionsViewModelValidator.cs
+++ b/src/EA.Weee.Web/Areas/AATFReturn/ViewModels/Validation/SelectReportOptionsViewModelValidator.cs
@@ -20,7 +20,7 @@
 
                     if (isParentSelected && !instance.DcfPossibleValues.Contains(instance.DcfSelectedValue))
                     {
-                        context.AddFailure(new ValidationFailure($"DcfSelectedValue", $"You must tell us whether any of the non-obligated WEEE was retained by a DCF"));
+                        context.AddFailure(new ValidationFailure($"DcfSelectedValue-0", $"You must tell us whether any of the non-obligated WEEE was retained by a DCF"));
                     }
                 }
             });

--- a/src/EA.Weee.Web/Areas/AATFReturn/Views/SelectReportOptions/Index.cshtml
+++ b/src/EA.Weee.Web/Areas/AATFReturn/Views/SelectReportOptions/Index.cshtml
@@ -64,6 +64,7 @@
                         }
                         else
                         {
+                            var errorClass = @Model.HasDcfError == true ? "error" : "";            
                             <div id="dcfSection" class="dcf-section">
                                 <h3 class="govuk-heading-m govuk-!-font-size-24" style="font-weight: normal;">
                                     @Model.ReportOnQuestions[i].Description?
@@ -71,7 +72,7 @@
                                 <p class="govuk-body govuk-!-font-size-16">
                                     This is WEEE that a local authority who is a DCF operator has been allowed to keep under regulation 53 and has sent to you for treatment.
                                 </p>
-                                <div class="govuk-form-group @Html.Gds().FormGroupClass(m => m.DcfSelectedValue)" id="WeeeReusedOptions">
+                                <div class="govuk-form-group @errorClass @Html.Gds().FormGroupClass(m => m.DcfSelectedValue)" id="WeeeReusedOptions">
                                     @this.WeeeGds().RadioButtonsFor(
                                         m => m.DcfSelectedValue,
                                         Model.DcfPossibleValues,


### PR DESCRIPTION
Task: 70363

After lots of playing around it seems that in the SelectReportOptionsViewModelValidator the validation failure was adding a key to an element that wasn't a valid element to focus on. But changing it to be a valid element, would fail the javascript and the options would be hidden on returning of the view.

So I added a flag to the view model that sets a class to display error which would let the javascript work.