### PR TITLE
Previousy had removed the grey box from the screens, but didn't remov…

### DIFF
--- a/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/NonObligatedControllerTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/NonObligatedControllerTests.cs
@@ -90,7 +90,6 @@
         {
             var organisationId = Guid.NewGuid();
             var @return = A.Fake<ReturnData>();
-            var schemeInfo = A.Fake<SchemePublicInfo>();
             var operatorData = A.Fake<OperatorData>();
             const string orgName = "orgName";
 
@@ -98,13 +97,12 @@
             A.CallTo(() => operatorData.OrganisationId).Returns(organisationId);
             A.CallTo(() => @return.ReturnOperatorData).Returns(operatorData);
             A.CallTo(() => cache.FetchOrganisationName(organisationId)).Returns(orgName);
-            A.CallTo(() => cache.FetchSchemePublicInfo(organisationId)).Returns(schemeInfo);
 
             await controller.Index(A.Dummy<Guid>(), A.Dummy<bool>());
 
             breadcrumb.ExternalActivity.Should().Be(BreadCrumbConstant.AatfReturn);
             breadcrumb.ExternalOrganisation.Should().Be(orgName);
-            breadcrumb.SchemeInfo.Should().Be(schemeInfo);
+            breadcrumb.OrganisationId.Should().Be(organisationId);
         }
 
         [Fact]

--- a/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/NonObligatedValuesCopyPasteControllerTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/NonObligatedValuesCopyPasteControllerTests.cs
@@ -83,7 +83,6 @@
         {
             var organisationId = Guid.NewGuid();
             var @return = A.Fake<ReturnData>();
-            var schemeInfo = A.Fake<SchemePublicInfo>();
             var operatorData = A.Fake<OperatorData>();
             const string orgName = "orgName";
 
@@ -91,13 +90,12 @@
             A.CallTo(() => operatorData.OrganisationId).Returns(organisationId);
             A.CallTo(() => @return.ReturnOperatorData).Returns(operatorData);
             A.CallTo(() => cache.FetchOrganisationName(organisationId)).Returns(orgName);
-            A.CallTo(() => cache.FetchSchemePublicInfo(organisationId)).Returns(schemeInfo);
 
             await controller.Index(A.Dummy<Guid>(), A.Dummy<bool>());
 
             breadcrumb.ExternalActivity.Should().Be(BreadCrumbConstant.AatfReturn);
             breadcrumb.ExternalOrganisation.Should().Be(orgName);
-            breadcrumb.SchemeInfo.Should().Be(schemeInfo);
+            breadcrumb.OrganisationId.Should().Be(organisationId);
         }
 
         [Fact]

--- a/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/ObligatedReceivedControllerTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/ObligatedReceivedControllerTests.cs
@@ -144,7 +144,6 @@
         {
             var organisationId = Guid.NewGuid();
             var @return = A.Fake<ReturnData>();
-            var schemeInfo = A.Fake<SchemePublicInfo>();
             var operatorData = A.Fake<OperatorData>();
             const string orgName = "orgName";
 
@@ -152,13 +151,12 @@
             A.CallTo(() => operatorData.OrganisationId).Returns(organisationId);
             A.CallTo(() => @return.ReturnOperatorData).Returns(operatorData);
             A.CallTo(() => cache.FetchOrganisationName(organisationId)).Returns(orgName);
-            A.CallTo(() => cache.FetchSchemePublicInfo(organisationId)).Returns(schemeInfo);
 
             await controller.Index(A.Dummy<Guid>(), A.Dummy<Guid>(), A.Dummy<Guid>());
 
             breadcrumb.ExternalActivity.Should().Be(BreadCrumbConstant.AatfReturn);
             breadcrumb.ExternalOrganisation.Should().Be(orgName);
-            breadcrumb.SchemeInfo.Should().Be(schemeInfo);
+            breadcrumb.OrganisationId.Should().Be(organisationId);
         }
 
         [Fact]

--- a/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/ObligatedReusedControllerTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/ObligatedReusedControllerTests.cs
@@ -84,7 +84,6 @@
         {
             var organisationId = Guid.NewGuid();
             var @return = A.Fake<ReturnData>();
-            var schemeInfo = A.Fake<SchemePublicInfo>();
             var operatorData = A.Fake<OperatorData>();
 
             const string orgName = "orgName";
@@ -93,13 +92,12 @@
             A.CallTo(() => operatorData.OrganisationId).Returns(organisationId);
             A.CallTo(() => @return.ReturnOperatorData).Returns(operatorData);
             A.CallTo(() => cache.FetchOrganisationName(organisationId)).Returns(orgName);
-            A.CallTo(() => cache.FetchSchemePublicInfo(organisationId)).Returns(schemeInfo);
 
             await controller.Index(A.Dummy<Guid>(), A.Dummy<Guid>());
 
             breadcrumb.ExternalActivity.Should().Be(BreadCrumbConstant.AatfReturn);
             breadcrumb.ExternalOrganisation.Should().Be(orgName);
-            breadcrumb.SchemeInfo.Should().Be(schemeInfo);
+            breadcrumb.OrganisationId.Should().Be(organisationId);
         }
 
         [Fact]

--- a/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/ObligatedSentOnValuesCopyPasteControllerTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/ObligatedSentOnValuesCopyPasteControllerTests.cs
@@ -83,7 +83,6 @@
         {
             Guid organisationId = Guid.NewGuid();
             ReturnData returnData = A.Fake<ReturnData>();
-            SchemePublicInfo schemeInfo = A.Fake<SchemePublicInfo>();
             OperatorData operatorData = A.Fake<OperatorData>();
             const string orgName = "orgName";
 
@@ -91,13 +90,12 @@
             A.CallTo(() => operatorData.OrganisationId).Returns(organisationId);
             A.CallTo(() => returnData.ReturnOperatorData).Returns(operatorData);
             A.CallTo(() => cache.FetchOrganisationName(organisationId)).Returns(orgName);
-            A.CallTo(() => cache.FetchSchemePublicInfo(organisationId)).Returns(schemeInfo);
 
             await controller.Index(A.Dummy<Guid>(), A.Dummy<Guid>(), A.Dummy<Guid>(), A.Dummy<Guid>(), A.Dummy<string>());
 
             breadcrumb.ExternalActivity.Should().Be(BreadCrumbConstant.AatfReturn);
             breadcrumb.ExternalOrganisation.Should().Be(orgName);
-            breadcrumb.SchemeInfo.Should().Be(schemeInfo);
+            breadcrumb.OrganisationId.Should().Be(organisationId);
         }
 
         [Fact]

--- a/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/ObligatedValuesCopyPasteControllerTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/ObligatedValuesCopyPasteControllerTests.cs
@@ -121,7 +121,6 @@
         {
             var organisationId = Guid.NewGuid();
             var @return = A.Fake<ReturnData>();
-            var schemeInfo = A.Fake<SchemePublicInfo>();
             var operatorData = A.Fake<OperatorData>();
             const string orgName = "orgName";
 
@@ -129,13 +128,12 @@
             A.CallTo(() => operatorData.OrganisationId).Returns(organisationId);
             A.CallTo(() => @return.ReturnOperatorData).Returns(operatorData);
             A.CallTo(() => cache.FetchOrganisationName(organisationId)).Returns(orgName);
-            A.CallTo(() => cache.FetchSchemePublicInfo(organisationId)).Returns(schemeInfo);
 
             await controller.Index(A.Dummy<Guid>(), A.Dummy<Guid>(), A.Dummy<Guid>(), A.Dummy<ObligatedType>());
 
             breadcrumb.ExternalActivity.Should().Be(BreadCrumbConstant.AatfReturn);
             breadcrumb.ExternalOrganisation.Should().Be(orgName);
-            breadcrumb.SchemeInfo.Should().Be(schemeInfo);
+            breadcrumb.OrganisationId.Should().Be(organisationId);
         }
 
         [Fact]

--- a/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/ReceivedPcsListControllerTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/ReceivedPcsListControllerTests.cs
@@ -54,7 +54,6 @@
         {
             var organisationId = Guid.NewGuid();
             var schemeData = A.Fake<SchemeDataList>();
-            var schemeInfo = A.Fake<SchemePublicInfo>();
             var operatorData = A.Fake<OperatorData>();
             const string orgName = "orgName";
 
@@ -63,13 +62,12 @@
             A.CallTo(() => schemeData.OperatorData).Returns(operatorData);
             A.CallTo(() => schemeData.SchemeDataItems).Returns(A.Fake<List<SchemeData>>());
             A.CallTo(() => cache.FetchOrganisationName(organisationId)).Returns(orgName);
-            A.CallTo(() => cache.FetchSchemePublicInfo(organisationId)).Returns(schemeInfo);
 
             await controller.Index(A.Dummy<Guid>(), A.Dummy<Guid>());
 
             breadcrumb.ExternalActivity.Should().Be(BreadCrumbConstant.AatfReturn);
             breadcrumb.ExternalOrganisation.Should().Be(orgName);
-            breadcrumb.SchemeInfo.Should().Be(schemeInfo);
+            breadcrumb.OrganisationId.Should().Be(organisationId);
         }
 
         [Fact]

--- a/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/ReusedOffSiteControllerTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/ReusedOffSiteControllerTests.cs
@@ -47,17 +47,15 @@
         public async void IndexGet_GivenValidViewModel_BreadcrumbShouldBeSet()
         {
             var organisationId = Guid.NewGuid();
-            var schemeInfo = A.Fake<SchemePublicInfo>();
             const string orgName = "orgName";
 
             A.CallTo(() => cache.FetchOrganisationName(organisationId)).Returns(orgName);
-            A.CallTo(() => cache.FetchSchemePublicInfo(organisationId)).Returns(schemeInfo);
 
             await controller.Index(organisationId, A.Dummy<Guid>(), A.Dummy<Guid>());
 
             breadcrumb.ExternalActivity.Should().Be(BreadCrumbConstant.AatfReturn);
             breadcrumb.ExternalOrganisation.Should().Be(orgName);
-            breadcrumb.SchemeInfo.Should().Be(schemeInfo);
+            breadcrumb.OrganisationId.Should().Be(organisationId);
         }
 
         [Fact]
@@ -112,19 +110,17 @@
         public async void IndexPost_GivenInvalidViewModel_BreadcrumbShouldBeSet()
         {
             var organisationId = Guid.NewGuid();
-            var schemeInfo = A.Fake<SchemePublicInfo>();
             const string orgName = "orgName";
             var model = new ReusedOffSiteViewModel() { OrganisationId = organisationId };
             controller.ModelState.AddModelError("error", "error");
 
             A.CallTo(() => cache.FetchOrganisationName(organisationId)).Returns(orgName);
-            A.CallTo(() => cache.FetchSchemePublicInfo(organisationId)).Returns(schemeInfo);
 
             await controller.Index(model);
 
             breadcrumb.ExternalActivity.Should().Be(BreadCrumbConstant.AatfReturn);
             breadcrumb.ExternalOrganisation.Should().Be(orgName);
-            breadcrumb.SchemeInfo.Should().Be(schemeInfo);
+            breadcrumb.OrganisationId.Should().Be(organisationId);
         }
     }
 }

--- a/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/ReusedOffSiteCreateSiteControllerTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/ReusedOffSiteCreateSiteControllerTests.cs
@@ -59,17 +59,15 @@
         public async void IndexGet_GivenValidViewModel_BreadcrumbShouldBeSet()
         {
             var organisationId = Guid.NewGuid();
-            var schemeInfo = A.Fake<SchemePublicInfo>();
             const string orgName = "orgName";
 
             A.CallTo(() => cache.FetchOrganisationName(organisationId)).Returns(orgName);
-            A.CallTo(() => cache.FetchSchemePublicInfo(organisationId)).Returns(schemeInfo);
 
             await controller.Index(organisationId, A.Dummy<Guid>(), A.Dummy<Guid>(), A.Dummy<Guid?>());
 
             breadcrumb.ExternalActivity.Should().Be(BreadCrumbConstant.AatfReturn);
             breadcrumb.ExternalOrganisation.Should().Be(orgName);
-            breadcrumb.SchemeInfo.Should().Be(schemeInfo);
+            breadcrumb.OrganisationId.Should().Be(organisationId);
         }
 
         [Fact]
@@ -195,19 +193,17 @@
         public async void IndexPost_GivenInvalidViewModel_BreadcrumbShouldBeSet()
         {
             var organisationId = Guid.NewGuid();
-            var schemeInfo = A.Fake<SchemePublicInfo>();
             const string orgName = "orgName";
             var model = new ReusedOffSiteCreateSiteViewModel() { OrganisationId = organisationId, AddressData = new SiteAddressData() };
             controller.ModelState.AddModelError("error", "error");
 
             A.CallTo(() => cache.FetchOrganisationName(organisationId)).Returns(orgName);
-            A.CallTo(() => cache.FetchSchemePublicInfo(organisationId)).Returns(schemeInfo);
 
             await controller.Index(model);
 
             breadcrumb.ExternalActivity.Should().Be(BreadCrumbConstant.AatfReturn);
             breadcrumb.ExternalOrganisation.Should().Be(orgName);
-            breadcrumb.SchemeInfo.Should().Be(schemeInfo);
+            breadcrumb.OrganisationId.Should().Be(organisationId);
         }
     }
 }

--- a/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/ReusedOffSiteSummaryListControllerTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/ReusedOffSiteSummaryListControllerTests.cs
@@ -50,17 +50,15 @@
         public async void IndexGet_GivenValidViewModel_BreadcrumbShouldBeSet()
         {
             var organisationId = Guid.NewGuid();
-            var schemeInfo = A.Fake<SchemePublicInfo>();
             const string orgName = "orgName";
 
             A.CallTo(() => cache.FetchOrganisationName(organisationId)).Returns(orgName);
-            A.CallTo(() => cache.FetchSchemePublicInfo(organisationId)).Returns(schemeInfo);
 
             await controller.Index(organisationId, A.Dummy<Guid>(), A.Dummy<Guid>());
 
             breadcrumb.ExternalActivity.Should().Be(BreadCrumbConstant.AatfReturn);
             breadcrumb.ExternalOrganisation.Should().Be(orgName);
-            breadcrumb.SchemeInfo.Should().Be(schemeInfo);
+            breadcrumb.OrganisationId.Should().Be(organisationId);
         }
 
         [Fact]

--- a/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/ReusedRemoveSiteControllerTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/ReusedRemoveSiteControllerTests.cs
@@ -58,7 +58,6 @@
         {
             var organisationId = Guid.NewGuid();
             var siteId = Guid.NewGuid();
-            var schemeInfo = A.Fake<SchemePublicInfo>();
             const string orgName = "orgName";
 
             var siteAddressData = new SiteAddressData("TEST", "TEST", "TEST", "TEST", "TEST", "TEST", Guid.NewGuid(), "TEST");
@@ -73,24 +72,21 @@
 
             A.CallTo(() => apiClient.SendAsync(A<string>._, A<GetAatfSite>.Ignored)).Returns(addressTonnage);
             A.CallTo(() => cache.FetchOrganisationName(organisationId)).Returns(orgName);
-            A.CallTo(() => cache.FetchSchemePublicInfo(organisationId)).Returns(schemeInfo);
 
             await controller.Index(organisationId, A.Dummy<Guid>(), A.Dummy<Guid>(), siteId);
 
             breadcrumb.ExternalActivity.Should().Be(BreadCrumbConstant.AatfReturn);
             breadcrumb.ExternalOrganisation.Should().Be(orgName);
-            breadcrumb.SchemeInfo.Should().Be(schemeInfo);
+            breadcrumb.OrganisationId.Should().Be(organisationId);
         }
 
         [Fact]
         public async void IndexPost_GivenInvalidViewModel_BreadcrumbShouldBeSet()
         {
             var organisationId = Guid.NewGuid();
-            var schemeInfo = A.Fake<SchemePublicInfo>();
             const string orgName = "orgName";
 
             A.CallTo(() => cache.FetchOrganisationName(organisationId)).Returns(orgName);
-            A.CallTo(() => cache.FetchSchemePublicInfo(organisationId)).Returns(schemeInfo);
 
             controller.ModelState.AddModelError("error", "error");
             var viewModel = new ReusedRemoveSiteViewModel()
@@ -102,7 +98,7 @@
 
             breadcrumb.ExternalActivity.Should().Be(BreadCrumbConstant.AatfReturn);
             breadcrumb.ExternalOrganisation.Should().Be(orgName);
-            breadcrumb.SchemeInfo.Should().Be(schemeInfo);
+            breadcrumb.OrganisationId.Should().Be(organisationId);
         }
 
         [Fact]

--- a/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/SelectReportOptionsControllerTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/SelectReportOptionsControllerTests.cs
@@ -194,7 +194,6 @@
         {
             var organisationId = Guid.NewGuid();
             var returnId = Guid.NewGuid();
-            var schemeInfo = A.Fake<SchemePublicInfo>();
             const string orgName = "orgName";
             var model = new SelectReportOptionsViewModel()
             {
@@ -205,13 +204,12 @@
             controller.ModelState.AddModelError("error", "error");
 
             A.CallTo(() => cache.FetchOrganisationName(organisationId)).Returns(orgName);
-            A.CallTo(() => cache.FetchSchemePublicInfo(organisationId)).Returns(schemeInfo);
 
             await controller.Index(model);
 
             breadcrumb.ExternalActivity.Should().Be(BreadCrumbConstant.AatfReturn);
             breadcrumb.ExternalOrganisation.Should().Be(orgName);
-            breadcrumb.SchemeInfo.Should().Be(schemeInfo);
+            breadcrumb.OrganisationId.Should().Be(organisationId);
         }
 
         [Fact]

--- a/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/SelectReportOptionsDeselectControllerTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/SelectReportOptionsDeselectControllerTests.cs
@@ -188,7 +188,6 @@
         {
             var organisationId = Guid.NewGuid();
             var returnId = Guid.NewGuid();
-            var schemeInfo = A.Fake<SchemePublicInfo>();
             const string orgName = "orgName";
             var model = CreateSubmittedViewModel();
             model.ReturnId = returnId;
@@ -198,14 +197,13 @@
             controller.TempData["viewModel"] = CreateTempData();
 
             A.CallTo(() => cache.FetchOrganisationName(organisationId)).Returns(orgName);
-            A.CallTo(() => cache.FetchSchemePublicInfo(organisationId)).Returns(schemeInfo);
             A.CallTo(() => mapper.Map(A<SelectReportOptionsViewModel>._)).Returns(model);
 
             await controller.Index(model);
 
             breadcrumb.ExternalActivity.Should().Be(BreadCrumbConstant.AatfReturn);
             breadcrumb.ExternalOrganisation.Should().Be(orgName);
-            breadcrumb.SchemeInfo.Should().Be(schemeInfo);
+            breadcrumb.OrganisationId.Should().Be(organisationId);
         }
 
         [Fact]

--- a/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/SentOnRemoveSiteControllerTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/SentOnRemoveSiteControllerTests.cs
@@ -53,28 +53,24 @@
         public async void IndexGet_GivenValidViewModel_BreadcrumbShouldBeSet()
         {
             var organisationId = Guid.NewGuid();
-            var schemeInfo = A.Fake<SchemePublicInfo>();
             const string orgName = "orgName";
 
             A.CallTo(() => cache.FetchOrganisationName(organisationId)).Returns(orgName);
-            A.CallTo(() => cache.FetchSchemePublicInfo(organisationId)).Returns(schemeInfo);
 
             await controller.Index(organisationId, A.Dummy<Guid>(), A.Dummy<Guid>(), A.Dummy<Guid>());
 
             breadcrumb.ExternalActivity.Should().Be(BreadCrumbConstant.AatfReturn);
             breadcrumb.ExternalOrganisation.Should().Be(orgName);
-            breadcrumb.SchemeInfo.Should().Be(schemeInfo);
+            breadcrumb.OrganisationId.Should().Be(organisationId);
         }
 
         [Fact]
         public async void IndexPost_GivenInvalidViewModel_BreadcrumbShouldBeSet()
         {
             var organisationId = Guid.NewGuid();
-            var schemeInfo = A.Fake<SchemePublicInfo>();
             const string orgName = "orgName";
 
             A.CallTo(() => cache.FetchOrganisationName(organisationId)).Returns(orgName);
-            A.CallTo(() => cache.FetchSchemePublicInfo(organisationId)).Returns(schemeInfo);
 
             controller.ModelState.AddModelError("error", "error");
             var viewModel = new SentOnRemoveSiteViewModel()
@@ -86,7 +82,7 @@
 
             breadcrumb.ExternalActivity.Should().Be(BreadCrumbConstant.AatfReturn);
             breadcrumb.ExternalOrganisation.Should().Be(orgName);
-            breadcrumb.SchemeInfo.Should().Be(schemeInfo);
+            breadcrumb.OrganisationId.Should().Be(organisationId);
         }
 
         [Fact]

--- a/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/SubmittedReturnControllerTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/SubmittedReturnControllerTests.cs
@@ -92,7 +92,6 @@
         {
             var organisationId = Guid.NewGuid();
             var @return = A.Fake<ReturnData>();
-            var schemeInfo = A.Fake<SchemePublicInfo>();
             var operatorData = A.Fake<OperatorData>();
             const string orgName = "orgName";
 
@@ -100,7 +99,6 @@
             A.CallTo(() => operatorData.OrganisationId).Returns(organisationId);
             A.CallTo(() => @return.ReturnOperatorData).Returns(operatorData);
             A.CallTo(() => cache.FetchOrganisationName(organisationId)).Returns(orgName);
-            A.CallTo(() => cache.FetchSchemePublicInfo(organisationId)).Returns(schemeInfo);
 
             var returnId = Guid.NewGuid();
 
@@ -108,7 +106,7 @@
 
             breadcrumb.ExternalActivity.Should().Be(BreadCrumbConstant.AatfReturn);
             breadcrumb.ExternalOrganisation.Should().Be(orgName);
-            breadcrumb.SchemeInfo.Should().Be(schemeInfo);
+            breadcrumb.OrganisationId.Should().Be(organisationId);
         }
 
         [Fact]

--- a/src/EA.Weee.Web/Areas/AATFReturn/Controllers/ReturnsSummaryController.cs
+++ b/src/EA.Weee.Web/Areas/AATFReturn/Controllers/ReturnsSummaryController.cs
@@ -51,7 +51,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
     }
 }

--- a/src/EA.Weee.Web/Areas/AATFReturn/Controllers/ReusedRemoveSiteController.cs
+++ b/src/EA.Weee.Web/Areas/AATFReturn/Controllers/ReusedRemoveSiteController.cs
@@ -90,7 +90,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
 
         public virtual string GenerateAddress(AddressData address)

--- a/src/EA.Weee.Web/Areas/AATFReturn/Controllers/SelectReportOptionsController.cs
+++ b/src/EA.Weee.Web/Areas/AATFReturn/Controllers/SelectReportOptionsController.cs
@@ -149,7 +149,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
     }
 }

--- a/src/EA.Weee.Web/Areas/AATFReturn/Controllers/SelectReportOptionsDeselectController.cs
+++ b/src/EA.Weee.Web/Areas/AATFReturn/Controllers/SelectReportOptionsDeselectController.cs
@@ -110,7 +110,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
     }
 }

--- a/src/EA.Weee.Web/Areas/AATFReturn/Controllers/SentOnRemoveSiteController.cs
+++ b/src/EA.Weee.Web/Areas/AATFReturn/Controllers/SentOnRemoveSiteController.cs
@@ -90,7 +90,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
 
         public virtual string GenerateAddress(AatfAddressData address)

--- a/src/EA.Weee.Web/Areas/AatfReturn/Controllers/AatfTaskListController.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Controllers/AatfTaskListController.cs
@@ -60,7 +60,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
     }
 }

--- a/src/EA.Weee.Web/Areas/AatfReturn/Controllers/CheckYourReturnController.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Controllers/CheckYourReturnController.cs
@@ -66,7 +66,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
     }
 }

--- a/src/EA.Weee.Web/Areas/AatfReturn/Controllers/NonObligatedController.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Controllers/NonObligatedController.cs
@@ -89,7 +89,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
 
         //private async Task ValidateResult(NonObligatedValuesViewModel model, IWeeeClient client)

--- a/src/EA.Weee.Web/Areas/AatfReturn/Controllers/NonObligatedValuesCopyPasteController.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Controllers/NonObligatedValuesCopyPasteController.cs
@@ -70,7 +70,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
     }
 }

--- a/src/EA.Weee.Web/Areas/AatfReturn/Controllers/ObligatedReceivedController.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Controllers/ObligatedReceivedController.cs
@@ -83,7 +83,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
     }
 }

--- a/src/EA.Weee.Web/Areas/AatfReturn/Controllers/ObligatedReusedController.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Controllers/ObligatedReusedController.cs
@@ -91,7 +91,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
     }
 }

--- a/src/EA.Weee.Web/Areas/AatfReturn/Controllers/ObligatedSentOnController.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Controllers/ObligatedSentOnController.cs
@@ -86,7 +86,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
     }
 }

--- a/src/EA.Weee.Web/Areas/AatfReturn/Controllers/ObligatedSentOnValuesCopyPasteController.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Controllers/ObligatedSentOnValuesCopyPasteController.cs
@@ -69,7 +69,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
     }
 }

--- a/src/EA.Weee.Web/Areas/AatfReturn/Controllers/ObligatedValuesCopyPasteController.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Controllers/ObligatedValuesCopyPasteController.cs
@@ -83,7 +83,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
     }
 }

--- a/src/EA.Weee.Web/Areas/AatfReturn/Controllers/ReceivedPCSListController.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Controllers/ReceivedPCSListController.cs
@@ -70,7 +70,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
     }
 }

--- a/src/EA.Weee.Web/Areas/AatfReturn/Controllers/ReturnsController.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Controllers/ReturnsController.cs
@@ -77,7 +77,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
     }
 }

--- a/src/EA.Weee.Web/Areas/AatfReturn/Controllers/ReturnsController.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Controllers/ReturnsController.cs
@@ -19,7 +19,7 @@
         private readonly Func<IWeeeClient> apiClient;
         private readonly BreadcrumbService breadcrumb;
         private readonly IWeeeCache cache;
-        private readonly IMapper mapper;
+        private readonly IMapper mapper; 
 
         public ReturnsController(Func<IWeeeClient> apiClient, BreadcrumbService breadcrumb, IWeeeCache cache, IMapper mapper)
         {

--- a/src/EA.Weee.Web/Areas/AatfReturn/Controllers/ReusedOffSiteController.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Controllers/ReusedOffSiteController.cs
@@ -68,7 +68,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
     }
 }

--- a/src/EA.Weee.Web/Areas/AatfReturn/Controllers/ReusedOffSiteCreateSiteController.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Controllers/ReusedOffSiteCreateSiteController.cs
@@ -100,7 +100,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
     }
 }

--- a/src/EA.Weee.Web/Areas/AatfReturn/Controllers/ReusedOffSiteSummaryListController.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Controllers/ReusedOffSiteSummaryListController.cs
@@ -62,7 +62,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
     }
 }

--- a/src/EA.Weee.Web/Areas/AatfReturn/Controllers/SelectYourPCSController.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Controllers/SelectYourPCSController.cs
@@ -78,7 +78,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
     }
 }

--- a/src/EA.Weee.Web/Areas/AatfReturn/Controllers/SentOnCreateSiteController.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Controllers/SentOnCreateSiteController.cs
@@ -92,7 +92,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
     }
 }

--- a/src/EA.Weee.Web/Areas/AatfReturn/Controllers/SentOnCreateSiteOperatorController.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Controllers/SentOnCreateSiteOperatorController.cs
@@ -100,7 +100,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
     }
 }

--- a/src/EA.Weee.Web/Areas/AatfReturn/Controllers/SentOnSiteSummaryListController.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Controllers/SentOnSiteSummaryListController.cs
@@ -68,7 +68,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
     }
 }

--- a/src/EA.Weee.Web/Areas/AatfReturn/Controllers/SubmittedReturnController.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Controllers/SubmittedReturnController.cs
@@ -57,7 +57,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
     }
 }

--- a/src/EA.Weee.Web/Areas/Scheme/Controllers/DataReturnsController.cs
+++ b/src/EA.Weee.Web/Areas/Scheme/Controllers/DataReturnsController.cs
@@ -362,7 +362,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = "Manage EEE/WEEE data";
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
 
         private async Task<DataReturnForSubmission> FetchDataReturnUpload(Guid pcsId, Guid dataReturnUploadId)

--- a/src/EA.Weee.Web/Areas/Scheme/Controllers/HomeController.cs
+++ b/src/EA.Weee.Web/Areas/Scheme/Controllers/HomeController.cs
@@ -595,7 +595,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
     }
 }

--- a/src/EA.Weee.Web/Areas/Scheme/Controllers/MemberRegistrationController.cs
+++ b/src/EA.Weee.Web/Areas/Scheme/Controllers/MemberRegistrationController.cs
@@ -322,7 +322,7 @@
         {
             breadcrumb.ExternalOrganisation = await cache.FetchOrganisationName(organisationId);
             breadcrumb.ExternalActivity = activity;
-            breadcrumb.SchemeInfo = await cache.FetchSchemePublicInfo(organisationId);
+            breadcrumb.OrganisationId = organisationId;
         }
     }
 }

--- a/src/EA.Weee.Web/Services/BreadcrumbService.cs
+++ b/src/EA.Weee.Web/Services/BreadcrumbService.cs
@@ -1,6 +1,7 @@
 ﻿namespace EA.Weee.Web.Services
 {
     using EA.Weee.Core.Scheme;
+    using System;
 
     public class BreadcrumbService
     {
@@ -33,6 +34,8 @@
         /// Information about the scheme currently in scope.
         /// </summary>
         public SchemePublicInfo SchemeInfo { get; set; }
+
+        public Guid OrganisationId { get; set; }
 
         /// <summary>
         /// The activity currently in scope when accessing the test area.

--- a/src/EA.Weee.Web/Views/Shared/_WeeeTitle.cshtml
+++ b/src/EA.Weee.Web/Views/Shared/_WeeeTitle.cshtml
@@ -58,7 +58,7 @@
                         {
                             <li>
                                 @(this.WeeeGds().ActionLinkWithEventTracking("Activity",
-                                Url.UrlFor<EA.Weee.Web.Areas.Scheme.Controllers.HomeController>(a => a.ChooseActivity(Model.Breadcrumb.SchemeInfo.OrganisationId)),
+                                Url.UrlFor<EA.Weee.Web.Areas.Scheme.Controllers.HomeController>(a => a.ChooseActivity(Model.Breadcrumb.OrganisationId)),
                                     "Navigation",
                                     "External activity",
                                     null,


### PR DESCRIPTION
…e the code that set the scheme. However, the html that worked out the organisation actitivies used the scheme object that was set in the breadcrumb on each controller action. So instead a new property on the service for the organisataion id which can be used instead.

Bug: 71722

