### PR TITLE
Fix compliance year drop down

### DIFF
--- a/src/EA.Weee.Web/Areas/Admin/ViewModels/Aatf/FacilityViewModelBase.cs
+++ b/src/EA.Weee.Web/Areas/Admin/ViewModels/Aatf/FacilityViewModelBase.cs
@@ -64,18 +64,22 @@
             var validationResults = new List<ValidationResult>();
             var instance = validationContext.ObjectInstance as FacilityViewModelBase;
 
-            if (instance?.ApprovalDate != null)
+            if (instance != null)
             {
-                var input = instance.ApprovalDate.Value;
-
-                var startDate = new DateTime(instance.ComplianceYear, 1, 1);
-                var endDate = new DateTime(instance.ComplianceYear, 12, 31);
-
-                if (input < startDate || input > endDate)
+                if (instance.ApprovalDate.HasValue && instance.ComplianceYear != default(short))
                 {
-                    validationResults.Add(
-                        new ValidationResult($"Approval date must be between {startDate.ToString("dd/MM/yyyy")} and {endDate.ToString("dd/MM/yyyy")}",
-                        new List<string> { nameof(instance.ApprovalDate) }));
+                    var inputDate = instance.ApprovalDate.Value;
+                    var inputComplianceYear = instance.ComplianceYear;
+
+                    var startDate = new DateTime(inputComplianceYear, 1, 1);
+                    var endDate = new DateTime(inputComplianceYear, 12, 31);
+
+                    if (inputDate < startDate || inputDate > endDate)
+                    {
+                        validationResults.Add(
+                            new ValidationResult($"Approval date must be between {startDate.ToString("dd/MM/yyyy")} and {endDate.ToString("dd/MM/yyyy")}",
+                            new List<string> { nameof(instance.ApprovalDate) }));
+                    }
                 }
             }
 

--- a/src/EA.Weee.Web/Areas/Admin/Views/AddAatf/Add.cshtml
+++ b/src/EA.Weee.Web/Areas/Admin/Views/AddAatf/Add.cshtml
@@ -111,11 +111,19 @@
             }
         </div>
 
-        <div class="govuk-form-group">
+        var complianceYearState = ViewData.ModelState["ComplianceYear"];
+        var complianceYearHasErrors = complianceYearState != null && complianceYearState.Errors.Count > 0;
+        var selectedValue = Model.ComplianceYear == default(short) && !complianceYearHasErrors ? DateTime.Now.Year : Model.ComplianceYear;
+        <div class="govuk-form-group @if (complianceYearHasErrors) { <text>govuk-form-group--error error</text> }">
             @Html.Gds().LabelFor(m => m.ComplianceYear)
             @Html.Gds().ValidationMessageFor(m => m.ComplianceYear)
             <select class="govuk-!-width-one-third govuk-!-width-one-half form-control govuk-select" id="ComplianceYear" name="ComplianceYear">
-                <option selected="selected">@Model.ComplianceYearList.First()</option>
+                <option></option>
+                @{foreach (var year in Model.ComplianceYearList)
+                    {
+                        <option @if (year == selectedValue) { <text> selected="selected" </text> }>@year</option>
+                    }
+                }
             </select>
         </div>
 


### PR DESCRIPTION
It will now display all years if the list of years is updated, rather than just the first.
Also displays a blank option so that it looks like something is happening when the dropdown is clicked in IE and Edge