### PR TITLE
removed full stop from hint text

### DIFF
--- a/src/EA.Weee.Web/Views/NewUser/UserCreation.cshtml
+++ b/src/EA.Weee.Web/Views/NewUser/UserCreation.cshtml
@@ -35,7 +35,7 @@
         <div class="govuk-form-group @Html.Gds().FormGroupClass(m => m.Password)">
             @Html.Gds().LabelFor(m => m.Password)
             @Html.Gds().ValidationMessageFor(m => m.Password)
-            <p class="form-hint text">Your password has to be at least 8 characters long and must contain at least 1 lower-case letter, 1 upper-case letter and 1 number.</p>
+            <p class="form-hint text">Your password has to be at least 8 characters long and must contain at least 1 lower-case letter, 1 upper-case letter and 1 number</p>
             @Html.Gds().PasswordFor(m => m.Password, new {  @maxlength = CommonMaxFieldLengths.Password })
         </div>
         <div class="govuk-form-group @Html.Gds().FormGroupClass(m => m.ConfirmPassword)">


### PR DESCRIPTION
BUg: 71892

Removed full stop from hint, but Helen agrees that the error message should have a full stop as there are 2 sentances in the paragraph.