### PR TITLE
Remove rejected status

### DIFF
--- a/src/EA.Weee.Core/AatfReturn/AatfStatus.cs
+++ b/src/EA.Weee.Core/AatfReturn/AatfStatus.cs
@@ -7,7 +7,6 @@
         public static readonly AatfStatus Approved = new AatfStatus(1, "Approved");
         public static readonly AatfStatus Suspended = new AatfStatus(2, "Suspended");
         public static readonly AatfStatus Cancelled = new AatfStatus(3, "Cancelled");
-        public static readonly AatfStatus Rejected = new AatfStatus(4, "Rejected");
         protected AatfStatus()
         {
         }

--- a/src/EA.Weee.Domain/AatfReturn/AatfStatus.cs
+++ b/src/EA.Weee.Domain/AatfReturn/AatfStatus.cs
@@ -1,19 +1,12 @@
 ﻿namespace EA.Weee.Domain.AatfReturn
 {
     using Prsd.Core.Domain;
-    using Scheme;
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
 
     public class AatfStatus : Enumeration
     {
         public static readonly AatfStatus Approved = new AatfStatus(1, "Approved");
         public static readonly AatfStatus Suspended = new AatfStatus(2, "Suspended");
         public static readonly AatfStatus Cancelled = new AatfStatus(3, "Cancelled");
-        public static readonly AatfStatus Rejected = new AatfStatus(4, "Rejected");
         protected AatfStatus()
         {
         }


### PR DESCRIPTION
For task 72255 - Remove rejected status from AATF and AE status options. Same enum is used in both Aatf and AE screens.