### PR TITLE
removed the explaination from the list of users view

### DIFF
--- a/src/EA.Weee.Web/Areas/Scheme/Views/Home/ManageOrganisationUsers.cshtml
+++ b/src/EA.Weee.Web/Areas/Scheme/Views/Home/ManageOrganisationUsers.cshtml
@@ -25,16 +25,6 @@
                 RadioButtonLayout.Stacked)
         </div>
 
-        using (this.WeeeGds().ProgressiveDisclosure("What do these statuses mean?"))
-        {
-            <p>
-                Setting a user to 'active' will grant them access to all features and data available within the WEEE Online service for your organisation.
-            </p>
-            <p>
-                Setting the user to 'rejected' will remove their access to this organisation within the WEEE Online service.
-            </p>
-        }
-
         @(this.WeeeGds().Submit("Continue"))
     }
     <div>


### PR DESCRIPTION
When explaining to mansi where this was, I noticed I had added it to a page that didn't need it.