### PR TITLE
Restrict when submissions can be continued

### DIFF
--- a/src/EA.Weee.Core.Tests.Unit/EA.Weee.Core.Tests.Unit.csproj
+++ b/src/EA.Weee.Core.Tests.Unit/EA.Weee.Core.Tests.Unit.csproj
@@ -123,6 +123,7 @@
     <Compile Include="AatfReturn\AatfSchemeDataTests.cs" />
     <Compile Include="AatfReturn\AatfObligatedDataTests.cs" />
     <Compile Include="AatfReturn\WeeObligatedTests.cs" />
+    <Compile Include="Helpers\QuarterHelperTests.cs" />
     <Compile Include="Helpers\CategoryValueTotalCalculatorTests.cs" />
     <Compile Include="Helpers\CompanyRegistrationNumberFormatterTests.cs" />
     <Compile Include="Helpers\ComplexObject.cs" />

--- a/src/EA.Weee.Core.Tests.Unit/Helpers/QuarterHelperTests.cs
+++ b/src/EA.Weee.Core.Tests.Unit/Helpers/QuarterHelperTests.cs
@@ -1,0 +1,119 @@
+﻿namespace EA.Weee.Core.Tests.Unit.Helpers
+{
+    using System;
+    using AutoFixture;
+    using EA.Prsd.Core;
+    using EA.Weee.Core.AatfReturn;
+    using EA.Weee.Core.Helpers;
+    using Xunit;
+
+    public class QuaterHelperTests
+    {
+        private const string Q1 = "2018-01-01";
+        private const string Q2 = "2018-04-01";
+        private const string Q3 = "2018-07-01";
+        private const string Q4 = "2018-10-01";
+        private readonly Fixture fixture;
+
+        public QuaterHelperTests()
+        {
+            fixture = new Fixture();
+        }
+
+        [Theory]
+        [InlineData(Q1, 31, 03)]
+        [InlineData(Q2, 30, 06)]
+        [InlineData(Q3, 30, 09)]
+        [InlineData(Q4, 31, 12)]
+        public void IsOpenForReporting_DayBeforeReportingWindowOpens_ReturnsFalse(DateTime quarterStart, int currentDay, int currentMonth)
+        {
+            var quarter = new QuarterWindow(quarterStart, fixture.Create<DateTime>());
+
+            SystemTime.Freeze(new DateTime(2018, currentMonth, currentDay));
+            var result = QuarterHelper.IsOpenForReporting(quarter);
+            SystemTime.Unfreeze();
+
+            Assert.False(result);
+        }
+
+        [Theory]
+        [InlineData(Q1, 04, 2018)]
+        [InlineData(Q2, 07, 2018)]
+        [InlineData(Q3, 10, 2018)]
+        [InlineData(Q4, 01, 2019)]
+        public void IsOpenForReporting_DayReportingWindowOpens_ReturnsTrue(DateTime quarterStart, int currentMonth, int currentYear)
+        {
+            var quarter = new QuarterWindow(quarterStart, fixture.Create<DateTime>());
+
+            SystemTime.Freeze(new DateTime(currentYear, currentMonth, 01));
+            var result = QuarterHelper.IsOpenForReporting(quarter);
+            SystemTime.Unfreeze();
+
+            Assert.True(result);
+        }
+
+        [Theory]
+        [InlineData(Q1, 04, 2018)]
+        [InlineData(Q2, 07, 2018)]
+        [InlineData(Q3, 10, 2018)]
+        [InlineData(Q4, 01, 2019)]
+        public void IsOpenForReporting_DayAfterReportingWindowOpens_ReturnsTrue(DateTime quarterStart, int currentMonth, int currentYear)
+        {
+            var quarter = new QuarterWindow(quarterStart, fixture.Create<DateTime>());
+
+            SystemTime.Freeze(new DateTime(currentYear, currentMonth, 02));
+            var result = QuarterHelper.IsOpenForReporting(quarter);
+            SystemTime.Unfreeze();
+
+            Assert.True(result);
+        }
+
+        [Theory]
+        [InlineData(Q1)]
+        [InlineData(Q2)]
+        [InlineData(Q3)]
+        [InlineData(Q4)]
+        public void IsOpenForReporting_DayBeforeReportingWindowCloses_ReturnsTrue(DateTime quarterStart)
+        {
+            var quarter = new QuarterWindow(quarterStart, fixture.Create<DateTime>());
+
+            SystemTime.Freeze(new DateTime(2019, 03, 15));
+            var result = QuarterHelper.IsOpenForReporting(quarter);
+            SystemTime.Unfreeze();
+
+            Assert.True(result);
+        }
+
+        [Theory]
+        [InlineData(Q1)]
+        [InlineData(Q2)]
+        [InlineData(Q3)]
+        [InlineData(Q4)]
+        public void IsOpenForReporting_DayReportingWindowCloses_ReturnsTrue(DateTime quarterStart)
+        {
+            var quarter = new QuarterWindow(quarterStart, fixture.Create<DateTime>());
+
+            SystemTime.Freeze(new DateTime(2019, 03, 16));
+            var result = QuarterHelper.IsOpenForReporting(quarter);
+            SystemTime.Unfreeze();
+
+            Assert.True(result);
+        }
+
+        [Theory]
+        [InlineData(Q1)]
+        [InlineData(Q2)]
+        [InlineData(Q3)]
+        [InlineData(Q4)]
+        public void IsOpenForReporting_DayAfterReportingWindowCloses_ReturnsFalse(DateTime quarterStart)
+        {
+            var quarter = new QuarterWindow(quarterStart, fixture.Create<DateTime>());
+
+            SystemTime.Freeze(new DateTime(2019, 03, 17));
+            var result = QuarterHelper.IsOpenForReporting(quarter);
+            SystemTime.Unfreeze();
+
+            Assert.False(result);
+        }
+    }
+}

--- a/src/EA.Weee.Core/EA.Weee.Core.csproj
+++ b/src/EA.Weee.Core/EA.Weee.Core.csproj
@@ -80,6 +80,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Admin\AatfReports\AatfSubmissionHistoryData.cs" />
+    <Compile Include="Helpers\QuarterHelper.cs" />
     <Compile Include="Users\UserFilter.cs" />
     <Compile Include="AatfReturn\AatfSchemeData.cs" />
     <Compile Include="AatfReturn\AatfSize.cs" />

--- a/src/EA.Weee.Core/Helpers/QuarterHelper.cs
+++ b/src/EA.Weee.Core/Helpers/QuarterHelper.cs
@@ -1,0 +1,17 @@
+﻿namespace EA.Weee.Core.Helpers
+{
+    using System;
+    using EA.Prsd.Core;
+    using EA.Weee.Core.AatfReturn;
+
+    public static class QuarterHelper
+    {
+        public static bool IsOpenForReporting(QuarterWindow quarterWindow)
+        {
+            var reportingStartDate = quarterWindow.StartDate.AddMonths(3);
+            var reportingEndDate = new DateTime(quarterWindow.StartDate.Year + 1, 03, 16);
+
+            return reportingStartDate <= SystemTime.UtcNow && reportingEndDate >= SystemTime.UtcNow;
+        }
+    }
+}

--- a/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/AatfTaskListControllerTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/AatfTaskListControllerTests.cs
@@ -2,16 +2,15 @@
 {
     using System;
     using System.Web.Mvc;
+    using AutoFixture;
     using Core.DataReturns;
+    using EA.Prsd.Core;
     using EA.Prsd.Core.Mapper;
     using EA.Weee.Api.Client;
     using EA.Weee.Core.AatfReturn;
-    using EA.Weee.Core.Organisations;
     using EA.Weee.Requests.AatfReturn;
     using EA.Weee.Web.Areas.AatfReturn.Controllers;
-    using EA.Weee.Web.Areas.AatfReturn.ViewModels;
     using EA.Weee.Web.Constant;
-    using EA.Weee.Web.Controllers.Base;
     using EA.Weee.Web.Services;
     using EA.Weee.Web.Services.Caching;
     using EA.Weee.Web.ViewModels.Returns;
@@ -22,6 +21,7 @@
 
     public class AatfTaskListControllerTests
     {
+        private readonly Fixture fixture;
         private readonly IWeeeClient weeeClient;
         private readonly AatfTaskListController controller;
         private readonly BreadcrumbService breadcrumb;
@@ -29,6 +29,7 @@
 
         public AatfTaskListControllerTests()
         {
+            fixture = new Fixture();
             weeeClient = A.Fake<IWeeeClient>();
             breadcrumb = A.Fake<BreadcrumbService>();
             mapper = A.Fake<IMapper>();
@@ -50,10 +51,15 @@
         [Fact]
         public async void IndexGet_GivenValidViewModel_BreadcrumbShouldBeSet()
         {
-            var @return = A.Fake<ReturnData>();
-            A.CallTo(() => @return.OrganisationData).Returns(A.Fake<OrganisationData>());
+            var @return = fixture.Build<ReturnData>()
+                .With(r => r.Quarter, new Quarter(2019, QuarterType.Q1))
+                .With(r => r.QuarterWindow, new QuarterWindow(new DateTime(2019, 01, 01), new DateTime(2019, 03, 31)))
+                .Create();
+            A.CallTo(() => weeeClient.SendAsync(A<string>._, A<GetReturn>._)).Returns(@return);
 
+            SystemTime.Freeze(new DateTime(2019, 04, 01));
             await controller.Index(A.Dummy<Guid>());
+            SystemTime.Unfreeze();
 
             Assert.Equal(breadcrumb.ExternalActivity, BreadCrumbConstant.AatfReturn);
         }
@@ -71,22 +77,18 @@
         }
 
         [Fact]
-        public async void IndexGet_GivenAction_DefaultViewShouldBeReturned()
-        {
-            var result = await controller.Index(A.Dummy<Guid>()) as ViewResult;
-
-            result.ViewName.Should().BeEmpty();
-        }
-
-        [Fact]
         public async void IndexGet_GivenReturn_AatfTaskListViewModelShouldBeBuilt()
         {
-            var @return = A.Fake<ReturnData>();
+            var @return = fixture.Build<ReturnData>()
+                .With(r => r.Quarter, new Quarter(2019, QuarterType.Q1))
+                .With(r => r.QuarterWindow, new QuarterWindow(new DateTime(DateTime.Now.Year, 01, 01), new DateTime(DateTime.Now.Year, 03, 31)))
+                .Create();
 
-            A.CallTo(() => @return.OrganisationData).Returns(A.Fake<OrganisationData>());
             A.CallTo(() => weeeClient.SendAsync(A<string>._, A<GetReturn>._)).Returns(@return);
 
+            SystemTime.Freeze(new DateTime(2019, 04, 01));
             await controller.Index(A.Dummy<Guid>());
+            SystemTime.Unfreeze();
 
             A.CallTo(() => mapper.Map<ReturnViewModel>(@return)).MustHaveHappened(Repeated.Exactly.Once);
         }
@@ -95,14 +97,41 @@
         public async void IndexGet_GivenActionAndParameters_AatfTaskListViewModelShouldBeReturned()
         {
             var model = A.Fake<ReturnViewModel>();
-            var @return = A.Fake<ReturnData>();
+            var @return = fixture.Build<ReturnData>()
+                .With(r => r.Quarter, new Quarter(2019, QuarterType.Q1))
+                .With(r => r.QuarterWindow, new QuarterWindow(new DateTime(DateTime.Now.Year, 01, 01), new DateTime(DateTime.Now.Year, 03, 31)))
+                .Create();
 
-            A.CallTo(() => @return.OrganisationData).Returns(A.Fake<OrganisationData>());
             A.CallTo(() => mapper.Map<ReturnViewModel>(A<ReturnData>._)).Returns(model);
+            A.CallTo(() => weeeClient.SendAsync(A<string>._, A<GetReturn>._)).Returns(@return);
 
+            SystemTime.Freeze(new DateTime(2019, 04, 01));
             var result = await controller.Index(A.Dummy<Guid>()) as ViewResult;
+            SystemTime.Unfreeze();
 
             result.Model.Should().BeEquivalentTo(model);
+        }
+
+        [Fact]
+        public async void IndexGet_GivenClosedQuarter_RedirectedToErrorPage()
+        {
+            var model = A.Fake<ReturnViewModel>();
+            var @return = fixture.Build<ReturnData>()
+                .With(r => r.Quarter, new Quarter(2019, QuarterType.Q1))
+                .With(r => r.QuarterWindow, new QuarterWindow(new DateTime(DateTime.Now.Year, 01, 01), new DateTime(DateTime.Now.Year, 03, 31)))
+                .Create();
+
+            A.CallTo(() => mapper.Map<ReturnViewModel>(A<ReturnData>._)).Returns(model);
+            A.CallTo(() => weeeClient.SendAsync(A<string>._, A<GetReturn>._)).Returns(@return);
+
+            SystemTime.Freeze(new DateTime(2019, 01, 01));
+            var result = await controller.Index(A.Dummy<Guid>());
+            SystemTime.Unfreeze();
+
+            result.Should().BeOfType<RedirectToRouteResult>();
+            var redirectResult = result as RedirectToRouteResult;
+            redirectResult.RouteValues["controller"].Should().Be("Errors");
+            redirectResult.RouteValues["action"].Should().Be("QuarterClosed");
         }
     }
 }

--- a/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/SelectReportOptionsControllerTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Controller/SelectReportOptionsControllerTests.cs
@@ -6,6 +6,7 @@
     using System.Linq;
     using System.Web.Mvc;
     using Core.Scheme;
+    using EA.Prsd.Core;
     using EA.Prsd.Core.Mapper;
     using EA.Weee.Api.Client;
     using EA.Weee.Core.AatfReturn;
@@ -82,12 +83,32 @@
             const string reportingPeriod = "2019 Q1 Jan - Mar";
             var viewModel = CreateInitialViewModel();
             A.CallTo(() => mapper.Map(A<ReportOptionsToSelectReportOptionsViewModelMapTransfer>._)).Returns(viewModel);
-           
-            await controller.Index(organisationId, returnId);
+
+            SystemTime.Freeze(new DateTime(2019, 04, 01));
+            var result = await controller.Index(organisationId, returnId);
+            SystemTime.Unfreeze();
 
             Assert.Equal(breadcrumb.ExternalActivity, BreadCrumbConstant.AatfReturn);
 
             Assert.Contains(reportingPeriod, breadcrumb.QuarterDisplayInfo);
+        }
+
+        [Fact]
+        public async void IndexGet_GivenClosedQuarter_RedirectedToErrorPage()
+        {
+            var returnId = Guid.NewGuid();
+            var organisationId = Guid.NewGuid();
+            var viewModel = CreateInitialViewModel();
+            A.CallTo(() => mapper.Map(A<ReportOptionsToSelectReportOptionsViewModelMapTransfer>._)).Returns(viewModel);
+
+            SystemTime.Freeze(new DateTime(2019, 01, 01));
+            var result = await controller.Index(organisationId, returnId);
+            SystemTime.Unfreeze();
+
+            result.Should().BeOfType<RedirectToRouteResult>();
+            var redirectResult = result as RedirectToRouteResult;
+            redirectResult.RouteValues["controller"].Should().Be("Errors");
+            redirectResult.RouteValues["action"].Should().Be("QuarterClosed");
         }
 
         [Fact]
@@ -310,7 +331,7 @@
             {
                 OrganisationId = A.Dummy<Guid>(),
                 ReturnId = A.Dummy<Guid>(),
-                ReturnData = new ReturnData() { Id = Guid.NewGuid(), Quarter = new Quarter(2019, QuarterType.Q1), QuarterWindow = new QuarterWindow(new DateTime(2019, 1, 1), new DateTime(2019, 3, 30)) }
+                ReturnData = new ReturnData() { Id = Guid.NewGuid(), Quarter = new Quarter(2019, QuarterType.Q1), QuarterWindow = new QuarterWindow(new DateTime(2019, 1, 1), new DateTime(2019, 3, 31)) }
             };
 
             return model;

--- a/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Mapping/ToViewModel/ReturnStatusToReturnDisplayOptionsMapperTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/AatfReturn/Mapping/ToViewModel/ReturnStatusToReturnDisplayOptionsMapperTests.cs
@@ -1,6 +1,8 @@
 ﻿namespace EA.Weee.Web.Tests.Unit.Areas.AatfReturn.Mapping.ToViewModel
 {
+    using System;
     using Core.AatfReturn;
+    using EA.Prsd.Core;
     using FluentAssertions;
     using Web.Areas.AatfReturn.Mappings.ToViewModel;
     using Xunit;
@@ -15,9 +17,11 @@
         }
 
         [Fact]
-        public void Map_GivenReturnStatusIsCreated_DisplayOptionsShouldBeSet()
+        public void Map_GivenReturnStatusIsCreated_QuarterOpen_DisplayOptionsShouldBeSet()
         {
-            var displayOptions = mapper.Map(ReturnStatus.Created);
+            SystemTime.Freeze(new DateTime(2019, 04, 01));
+            var displayOptions = mapper.Map((ReturnStatus.Created, new QuarterWindow(new DateTime(2019, 01, 01), new DateTime(2019, 03, 31))));
+            SystemTime.Unfreeze();
             
             displayOptions.DisplayContinue.Should().BeTrue();
             displayOptions.DisplayEdit.Should().BeFalse();
@@ -25,9 +29,31 @@
         }
 
         [Fact]
-        public void Constructor_GivenReturnStatusIsSubmitted_DisplayOptionsShouldBeSet()
+        public void Map_GivenReturnStatusIsCreated_QuarterClosed_DisplayOptionsShouldBeSet()
         {
-            var displayOptions = mapper.Map(ReturnStatus.Submitted);
+            var displayOptions = mapper.Map((ReturnStatus.Created, new QuarterWindow(new DateTime(2000, 01, 01), new DateTime(2000, 03, 31))));
+
+            displayOptions.DisplayContinue.Should().BeFalse();
+            displayOptions.DisplayEdit.Should().BeFalse();
+            displayOptions.DisplaySummary.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Constructor_GivenReturnStatusIsSubmitted_QuarterOpen_DisplayOptionsShouldBeSet()
+        {
+            SystemTime.Freeze(new DateTime(2019, 04, 01));
+            var displayOptions = mapper.Map((ReturnStatus.Submitted, new QuarterWindow(new DateTime(2019, 01, 01), new DateTime(2019, 03, 31))));
+            SystemTime.Unfreeze();
+
+            displayOptions.DisplayContinue.Should().BeFalse();
+            displayOptions.DisplayEdit.Should().BeTrue();
+            displayOptions.DisplaySummary.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Constructor_GivenReturnStatusIsSubmitted_QuarterClosed_DisplayOptionsShouldBeSet()
+        {
+            var displayOptions = mapper.Map((ReturnStatus.Submitted, new QuarterWindow(new DateTime(2000, 01, 01), new DateTime(2000, 03, 31))));
 
             displayOptions.DisplayContinue.Should().BeFalse();
             displayOptions.DisplayEdit.Should().BeTrue();

--- a/src/EA.Weee.Web.Tests.Unit/ViewModels/Returns/Mappings/ToViewModel/ReturnViewModelToReturnsItemViewModelTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/ViewModels/Returns/Mappings/ToViewModel/ReturnViewModelToReturnsItemViewModelTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using Core.AatfReturn;
+    using EA.Prsd.Core;
     using EA.Weee.Web.ViewModels.Returns;
     using EA.Weee.Web.ViewModels.Returns.Mappings.ToViewModel;
     using FakeItEasy;
@@ -49,24 +50,31 @@
         [Fact]
         public void Map_GivenSource_ReturnDisplayOptionsListShouldBeMapped()
         {
-            var returnViewModel = new ReturnData() { ReturnStatus = ReturnStatus.Created };
+            var quarterWindow = new QuarterWindow(new DateTime(2019, 01, 01), new DateTime(2019, 03, 31));
+            var returnViewModel = new ReturnData() { ReturnStatus = ReturnStatus.Created, QuarterWindow = quarterWindow };
 
+            SystemTime.Freeze(new DateTime(2019, 04, 01));
             var result = mapper.Map(returnViewModel);
+            SystemTime.Unfreeze();
 
-            A.CallTo(() => genericMapper.Map<ReturnsListDisplayOptions>(returnViewModel.ReturnStatus)).MustHaveHappened(Repeated.Exactly.Once);
+            var expectedTuple = (returnViewModel.ReturnStatus, quarterWindow);
+            A.CallTo(() => genericMapper.Map<ReturnsListDisplayOptions>(expectedTuple)).MustHaveHappened(Repeated.Exactly.Once);
         }
 
         [Fact]
         public void Map_GivenSource_ReturnDisplayOptionsListAndReturned()
         {
-            var returnViewModel = new ReturnData() { ReturnStatus = ReturnStatus.Created };
+            var quarterWindow = new QuarterWindow(new DateTime(2019, 01, 01), new DateTime(2019, 03, 31));
+            var returnViewModel = new ReturnData() { ReturnStatus = ReturnStatus.Created, QuarterWindow = quarterWindow };
             var returnsListDisplayOptions = new ReturnsListDisplayOptions();
+            var expectedTuple = (returnViewModel.ReturnStatus, quarterWindow);
+            A.CallTo(() => genericMapper.Map<ReturnsListDisplayOptions>(expectedTuple)).Returns(returnsListDisplayOptions);
 
-            A.CallTo(() => genericMapper.Map<ReturnsListDisplayOptions>(returnViewModel.ReturnStatus)).Returns(returnsListDisplayOptions);
-
+            SystemTime.Freeze(new DateTime(2019, 04, 01));
             var result = mapper.Map(returnViewModel);
+            SystemTime.Unfreeze();
 
-            A.CallTo(() => genericMapper.Map<ReturnsListDisplayOptions>(returnViewModel.ReturnStatus)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => genericMapper.Map<ReturnsListDisplayOptions>(expectedTuple)).MustHaveHappened(Repeated.Exactly.Once);
             result.ReturnsListDisplayOptions.Should().Be(returnsListDisplayOptions);
         }
 

--- a/src/EA.Weee.Web/Areas/AatfReturn/Controllers/AatfTaskListController.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Controllers/AatfTaskListController.cs
@@ -3,9 +3,11 @@
     using Attributes;
     using EA.Prsd.Core.Mapper;
     using EA.Weee.Api.Client;
+    using EA.Weee.Core.Helpers;
     using EA.Weee.Requests.AatfReturn;
     using EA.Weee.Requests.Organisations;
     using EA.Weee.Web.Constant;
+    using EA.Weee.Web.Controllers;
     using EA.Weee.Web.Infrastructure;
     using EA.Weee.Web.Services;
     using EA.Weee.Web.Services.Caching;
@@ -36,6 +38,11 @@
             using (var client = apiClient())
             {
                 var @return = await client.SendAsync(User.GetAccessToken(), new GetReturn(returnId, false));
+
+                if (!QuarterHelper.IsOpenForReporting(@return.QuarterWindow))
+                {
+                    return RedirectToAction("QuarterClosed", "Errors", new { area = string.Empty });
+                }
 
                 var viewModel = mapper.Map<ReturnViewModel>(@return);
                 viewModel.OrganisationId = @return.OrganisationData.Id;

--- a/src/EA.Weee.Web/Areas/AatfReturn/Controllers/SelectReportOptionsController.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Controllers/SelectReportOptionsController.cs
@@ -9,6 +9,7 @@
     using EA.Weee.Api.Client;
     using EA.Weee.Core.AatfReturn;
     using EA.Weee.Core.DataReturns;
+    using EA.Weee.Core.Helpers;
     using EA.Weee.Requests.AatfReturn;
     using EA.Weee.Web.Areas.AatfReturn.Attributes;
     using EA.Weee.Web.Areas.AatfReturn.Mappings.ToViewModel;
@@ -56,6 +57,11 @@
                     ReportOnQuestions = await client.SendAsync(User.GetAccessToken(), new GetReportOnQuestion()),
                     ReturnData = await client.SendAsync(User.GetAccessToken(), new GetReturn(returnId, false))
                 });
+
+                if (!QuarterHelper.IsOpenForReporting(viewModel.ReturnData.QuarterWindow))
+                {
+                    return RedirectToAction("QuarterClosed", "Errors", new { area = string.Empty });
+                }
 
                 await SetBreadcrumb(organisationId, BreadCrumbConstant.AatfReturn, DisplayHelper.FormatQuarter(viewModel.ReturnData.Quarter, viewModel.ReturnData.QuarterWindow));
 

--- a/src/EA.Weee.Web/Areas/AatfReturn/Controllers/SelectYourPCSController.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Controllers/SelectYourPCSController.cs
@@ -9,6 +9,7 @@
     using EA.Weee.Api.Client;
     using EA.Weee.Core.AatfReturn;
     using EA.Weee.Core.DataReturns;
+    using EA.Weee.Core.Helpers;
     using EA.Weee.Core.Scheme;
     using EA.Weee.Requests.AatfReturn;
     using EA.Weee.Requests.Scheme;
@@ -54,6 +55,11 @@
                 };
 
                 var @return = await client.SendAsync(User.GetAccessToken(), new GetReturn(returnId, false));
+
+                if (!QuarterHelper.IsOpenForReporting(@return.QuarterWindow))
+                {
+                    return RedirectToAction("QuarterClosed", "Errors", new { area = string.Empty });
+                }
 
                 await SetBreadcrumb(organisationId, BreadCrumbConstant.AatfReturn, DisplayHelper.FormatQuarter(@return.Quarter, @return.QuarterWindow));
 

--- a/src/EA.Weee.Web/Areas/AatfReturn/Mappings/ToViewModel/ReturnStatusToReturnDisplayOptionsMap.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Mappings/ToViewModel/ReturnStatusToReturnDisplayOptionsMap.cs
@@ -1,15 +1,16 @@
 ﻿namespace EA.Weee.Web.Areas.AatfReturn.Mappings.ToViewModel
 {
     using Core.AatfReturn;
+    using EA.Weee.Core.Helpers;
     using Prsd.Core.Mapper;
 
-    public class ReturnStatusToReturnDisplayOptionsMap : IMap<ReturnStatus, ReturnsListDisplayOptions>
+    public class ReturnStatusToReturnDisplayOptionsMap : IMap<(ReturnStatus status, QuarterWindow quarterWindow), ReturnsListDisplayOptions>
     {
-        public ReturnsListDisplayOptions Map(ReturnStatus source)
+        public ReturnsListDisplayOptions Map((ReturnStatus status, QuarterWindow quarterWindow) source)
         {
             var options = new ReturnsListDisplayOptions();
 
-            if (source == ReturnStatus.Created)
+            if (source.status == ReturnStatus.Created && QuarterHelper.IsOpenForReporting(source.quarterWindow))
             {
                 options.DisplayContinue = true;
             }
@@ -18,7 +19,7 @@
                 options.DisplayEdit = true;
             }
 
-            options.DisplaySummary = source == ReturnStatus.Submitted;
+            options.DisplaySummary = source.status == ReturnStatus.Submitted;
 
             return options;
         }

--- a/src/EA.Weee.Web/Areas/AatfReturn/Mappings/ToViewModel/ReturnStatusToReturnDisplayOptionsMap.cs
+++ b/src/EA.Weee.Web/Areas/AatfReturn/Mappings/ToViewModel/ReturnStatusToReturnDisplayOptionsMap.cs
@@ -10,9 +10,9 @@
         {
             var options = new ReturnsListDisplayOptions();
 
-            if (source.status == ReturnStatus.Created && QuarterHelper.IsOpenForReporting(source.quarterWindow))
+            if (source.status == ReturnStatus.Created)
             {
-                options.DisplayContinue = true;
+                options.DisplayContinue = QuarterHelper.IsOpenForReporting(source.quarterWindow);
             }
             else
             {

--- a/src/EA.Weee.Web/Controllers/ErrorsController.cs
+++ b/src/EA.Weee.Web/Controllers/ErrorsController.cs
@@ -33,6 +33,12 @@
         }
 
         [HttpGet]
+        public ActionResult QuarterClosed()
+        {
+            return View();
+        }
+
+        [HttpGet]
         public async Task<ActionResult> ErrorRedirect()
         {
             var authState = await weeeAuthorization.GetAuthorizationState();

--- a/src/EA.Weee.Web/EA.Weee.Web.csproj
+++ b/src/EA.Weee.Web/EA.Weee.Web.csproj
@@ -1176,6 +1176,7 @@
     <Content Include="Views\Shared\_ViewOrganisationDetails.cshtml" />
     <Content Include="Views\Shared\_WeeeFooter.cshtml" />
     <Content Include="Views\Shared\_WeeeFooterSupportLinks.cshtml" />
+    <Content Include="Views\Errors\QuarterClosed.cshtml" />
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>

--- a/src/EA.Weee.Web/ViewModels/Returns/Mappings/ToViewModel/ReturnToReturnsItemViewModelMapper.cs
+++ b/src/EA.Weee.Web/ViewModels/Returns/Mappings/ToViewModel/ReturnToReturnsItemViewModelMapper.cs
@@ -26,7 +26,7 @@
             var model = new ReturnsItemViewModel()
             {
                 ReturnViewModel = returnMap.Map(source),
-                ReturnsListDisplayOptions = mapper.Map<ReturnsListDisplayOptions>(source.ReturnStatus),
+                ReturnsListDisplayOptions = mapper.Map<ReturnsListDisplayOptions>((source.ReturnStatus, source.QuarterWindow)),
                 ReturnsListRedirectOptions = returnListRedirectMap.Map(source)
             };
 

--- a/src/EA.Weee.Web/Views/Errors/QuarterClosed.cshtml
+++ b/src/EA.Weee.Web/Views/Errors/QuarterClosed.cshtml
@@ -1,0 +1,13 @@
+﻿@{
+    Page.Title = "Reporting Window Closed";
+    Response.TrySkipIisCustomErrors = true;
+    Response.StatusCode = 403;
+}
+
+<h1 class="govuk-heading-l">@Page.Title</h1>
+
+<p>Sorry, the reporting window for this quarter has closed.</p>
+
+<p>
+    <a href="@Url.Action("ErrorRedirect", "Errors", new { area = ""})" class="govuk-button">Continue</a>
+</p>


### PR DESCRIPTION
Hides the link and redirects to an error page when the URL is accessed directly and the reporting window has closed.