### PR TITLE
left-aligned global title "Waste Electrical and Electronic Equipment …

### DIFF
--- a/src/EA.Weee.Web/Views/Shared/_Layout.GovUK.cshtml
+++ b/src/EA.Weee.Web/Views/Shared/_Layout.GovUK.cshtml
@@ -50,7 +50,7 @@
     <header class="govuk-header @Html.Raw(ViewBag.HeaderClass ?? string.Empty)" role="banner" data-module="govuk-header">
         <div class="govuk-header__container govuk-width-container">
             <div class="header-global">
-                <div class="govuk-header__logo">
+                <div class="govuk-header__logo" style="width: 200px;">
                     <a href="@Html.Raw(ViewBag.HomepageUrl ?? "https://www.gov.uk/")" title="@Html.Raw(ViewBag.LogoLinkTitle ?? "Go to the GOV.UK homepage")" id="logo" class="govuk-header__link govuk-header__link--homepage">
                         <span class="govuk-header__logotype">
 


### PR DESCRIPTION
…(WEEE)" in layout GovUK template
I have shrunk the logo to the left to enable the title to move to the left.