### PR TITLE
Bug - 43466 -A fix for returning to the selected tab before clicking View/Edit links 

### DIFF
--- a/src/EA.Weee.Web/Areas/Aatf/Views/ManageEvidenceNotes/ViewDraftEvidenceNote.cshtml
+++ b/src/EA.Weee.Web/Areas/Aatf/Views/ManageEvidenceNotes/ViewDraftEvidenceNote.cshtml
@@ -1,13 +1,13 @@
 ﻿
 @using EA.Weee.Core.AatfEvidence
 @using EA.Weee.Web.Areas.Aatf.Controllers
-@using EA.Weee.Web.Infrastructure
 @using EA.Weee.Web.RazorHelpers
 @using MvcNavigationHelpers
+@using EA.Weee.Web.Areas.Aatf.ViewModels;
 @model EA.Weee.Web.Areas.Aatf.ViewModels.ViewEvidenceNoteViewModel
 @{
     var title = Model.Status == NoteStatus.Draft ? "Draft evidence note" : "Submitted evidence note";
-
+    var navigateBackToSelectedTab = Model.Status == NoteStatus.Draft ? ManageEvidenceOverviewDisplayOption.EditDraftAndReturnedNotes : ManageEvidenceOverviewDisplayOption.ViewAllOtherEvidenceNotes;
     ViewBag.Title = title;
 }
 
@@ -16,12 +16,12 @@
 
     @if (Model.DisplayMessage)
     {
-        @(this.WeeeGds().BackLink(@Url.UrlFor<ManageEvidenceNotesController>(a => a.Index(Model.OrganisationId, Model.AatfId, null, null)), "Manage evidence notes"))
+        @(this.WeeeGds().BackLink(@Url.UrlFor<ManageEvidenceNotesController>(a => a.Index(Model.OrganisationId, Model.AatfId, navigateBackToSelectedTab, null)), "Manage evidence notes"))
         @(this.WeeeGds().Panel(Model.SuccessMessage))
     }
     else
     {
-        @(this.WeeeGds().BackLink(@Url.UrlFor<ManageEvidenceNotesController>(a => a.Index(Model.OrganisationId, Model.AatfId, null, null))))
+        @(this.WeeeGds().BackLink(@Url.UrlFor<ManageEvidenceNotesController>(a => a.Index(Model.OrganisationId, Model.AatfId, navigateBackToSelectedTab, null))))
     }
 
 


### PR DESCRIPTION
A fix for remembering which tab was selected before View/Edit link was selected so the user can return to that tab when clicks on the button 