### PR TITLE
PR- 45457 Clicking on the error message link is not shifting the focus to the element

### DIFF
--- a/src/EA.Weee.Web/Areas/Scheme/Views/TransferEvidence/TransferTonnage.cshtml
+++ b/src/EA.Weee.Web/Areas/Scheme/Views/TransferEvidence/TransferTonnage.cshtml
@@ -118,7 +118,7 @@
                                         <span class="govuk-visually-hidden" id="category-received-@category.CategoryId-@i.ToString()">Transfer received (tonnes) for @note.SubmittedBy and @category.CategoryDisplay</span>
                                         @Html.Gds().ValidationMessageFor(m => Model.TransferCategoryValues[elementCount].Received)
                                         @Html.TextBoxFor(m => Model.TransferCategoryValues[elementCount].Received,
-                                            new { @id = @elementCount + "Received" + @category.CategoryId, @class = "govuk-input tonnage-entry", aria_labelledby = "category-received-" + @category.CategoryId + "-" + @i.ToString(), autocomplete = "off", maxlength = CommonMaxFieldLengths.Tonnage })
+                                            new { @class = "govuk-input tonnage-entry", aria_labelledby = "category-received-" + @category.CategoryId + "-" + @i.ToString(), autocomplete = "off", maxlength = CommonMaxFieldLengths.Tonnage })
                                     </div>
                                 </td>
                                 <td class="govuk-table__cell govuk-!-text-align-right">
@@ -126,7 +126,7 @@
                                         <span class="govuk-visually-hidden" id="category-reused-@category.CategoryId-@i.ToString()">Transfer reused (tonnes) for @note.SubmittedBy and @category.CategoryDisplay</span>
                                         @Html.Gds().ValidationMessageFor(m => Model.TransferCategoryValues[elementCount].Reused)
                                         @Html.TextBoxFor(m => Model.TransferCategoryValues[elementCount].Reused,
-                                            new { id = @elementCount + "Reused" + @category.CategoryId, @class = "govuk-input tonnage-entry", aria_labelledby = "category-reused-" + @category.CategoryId + "-" + @i.ToString(), autocomplete = "off", maxlength = CommonMaxFieldLengths.Tonnage })
+                                            new { @class = "govuk-input tonnage-entry", aria_labelledby = "category-reused-" + @category.CategoryId + "-" + @i.ToString(), autocomplete = "off", maxlength = CommonMaxFieldLengths.Tonnage })
                                     </div>
                                 </td>
                             </tr>


### PR DESCRIPTION
Fixing a bug which was causing clicking on the error message on top to not display the field where the error message came from.