### PR TITLE
Feature/45587 bug fix approval validation

### DIFF
--- a/src/EA.Weee.Web/Areas/Scheme/Views/ManageEvidenceNotes/ReviewEvidenceNote.cshtml
+++ b/src/EA.Weee.Web/Areas/Scheme/Views/ManageEvidenceNotes/ReviewEvidenceNote.cshtml
@@ -48,12 +48,10 @@
                 Model.HintItems)
         </div>
 
-        <div id="reason-text" class="govuk-!-margin-bottom-7">
-            <div class="govuk-form-group @Html.Gds().FormGroupClass(m => m.Reason)" id="reason">
-                @Html.Gds().LabelFor(m => m.Reason, showOptionalLabel: false)
-                @Html.Gds().ValidationMessageFor(m => m.Reason)
-                @Html.TextAreaFor(m => m.Reason, htmlAttributes: new { @class = "govuk-textarea", @maxlength = "200", @title = "You can type up to 200 characters" })
-            </div>
+        <div class="govuk-form-group govuk-!-margin-bottom-7 @Html.Gds().FormGroupClass(m => m.Reason)" id="ReasonDiv">
+            @Html.Gds().LabelFor(m => m.Reason, showOptionalLabel: false)
+            @Html.Gds().ValidationMessageFor(m => m.Reason)
+            @Html.TextAreaFor(m => m.Reason, htmlAttributes: new { @id = "Reason", @class = "govuk-textarea", @maxlength = "200", @title = "You can type up to 200 characters" })
         </div>
 
         <div class="govuk-form-group">

--- a/src/EA.Weee.Web/Scripts/weee-application.js
+++ b/src/EA.Weee.Web/Scripts/weee-application.js
@@ -216,17 +216,22 @@
 });
 
 function initReviewEvidenceNote() {
-    document.getElementById("reason-text").style = "display: none;";
+    if ($("#ReasonDiv").hasClass("error")) {
+        document.getElementById("ReasonDiv").style = "display: block;";
+    }
+    else {
+        document.getElementById("ReasonDiv").style = "display: none;";
+    }
     document.getElementById("conditional-SelectedValue-0").style = "display: block;";
     document.getElementById("conditional-SelectedValue-1").style = "display: block;";
     document.getElementById("conditional-SelectedValue-2").style = "display: block;";
 
     function showReasonText(event) {
-        document.getElementById("reason-text").style = "display: block;";
+        document.getElementById("ReasonDiv").style = "display: block;";
     }
 
     function hideReasonText(event) {
-        document.getElementById("reason-text").style = "display: none;";
+        document.getElementById("ReasonDiv").style = "display: none;";
     }
 
     document.getElementById("SelectedValue-0").addEventListener("click", hideReasonText);


### PR DESCRIPTION
Changed javascript to leave reason displayed when an error condition is met - so that the error message at top of screen can jump to bottom of page and user can delete reason text before approval.