### PR TITLE
Feature/47929 bug fix accessibility element id not unique

### DIFF
--- a/src/EA.Weee.Web/Areas/Aatf/Views/ManageEvidenceNotes/Overview/EditDraftReturnedNotesOverview.cshtml
+++ b/src/EA.Weee.Web/Areas/Aatf/Views/ManageEvidenceNotes/Overview/EditDraftReturnedNotesOverview.cshtml
@@ -18,9 +18,8 @@
 
                 <section class="govuk-tabs__panel" id="editDraftReturnedNotes">
 
-                    @using (Html.BeginForm("Index", "ManageEvidenceNotes", FormMethod.Get))
+                    @using (Html.BeginForm("Index", "ManageEvidenceNotes", new RouteValueDictionary() { { "tab", Model.ActiveOverviewDisplayOption } }, FormMethod.Get))
                     {
-                        @Html.Hidden("tab2", Model.ActiveOverviewDisplayOption)
                         @Html.Hidden("ManageEvidenceNoteViewModel.SelectedComplianceYear", Model.ManageEvidenceNoteViewModel.SelectedComplianceYear)
                         <div class="govuk-!-width-full govuk-panel-grey-background govuk-!-padding-bottom-0 govuk-!-margin-bottom-0">
 

--- a/src/EA.Weee.Web/Areas/Aatf/Views/ManageEvidenceNotes/Overview/EditDraftReturnedNotesOverview.cshtml
+++ b/src/EA.Weee.Web/Areas/Aatf/Views/ManageEvidenceNotes/Overview/EditDraftReturnedNotesOverview.cshtml
@@ -20,7 +20,7 @@
 
                     @using (Html.BeginForm("Index", "ManageEvidenceNotes", FormMethod.Get))
                     {
-                        @Html.Hidden("tab", Model.ActiveOverviewDisplayOption)
+                        @Html.Hidden("tab2", Model.ActiveOverviewDisplayOption)
                         @Html.Hidden("ManageEvidenceNoteViewModel.SelectedComplianceYear", Model.ManageEvidenceNoteViewModel.SelectedComplianceYear)
                         <div class="govuk-!-width-full govuk-panel-grey-background govuk-!-padding-bottom-0 govuk-!-margin-bottom-0">
 

--- a/src/EA.Weee.Web/Areas/Aatf/Views/ManageEvidenceNotes/Overview/ViewAllOtherEvidenceOverview.cshtml
+++ b/src/EA.Weee.Web/Areas/Aatf/Views/ManageEvidenceNotes/Overview/ViewAllOtherEvidenceOverview.cshtml
@@ -13,10 +13,9 @@
 
                 <section class="govuk-tabs__panel" id="allOtherNotes">
 
-                    @using (Html.BeginForm("Index", "ManageEvidenceNotes", FormMethod.Get))
+                    @using (Html.BeginForm("Index", "ManageEvidenceNotes", new RouteValueDictionary() { { "tab", Model.ActiveOverviewDisplayOption } }, FormMethod.Get))
                     {
                         @Html.Gds().ValidationSummary()
-                        @Html.Hidden("tab3", Model.ActiveOverviewDisplayOption)
                         @Html.Hidden("ManageEvidenceNoteViewModel.SelectedComplianceYear", Model.ManageEvidenceNoteViewModel.SelectedComplianceYear)
                         <div class="govuk-!-width-full govuk-panel-grey-background govuk-!-padding-bottom-0 govuk-!-margin-bottom-0">
 

--- a/src/EA.Weee.Web/Areas/Aatf/Views/ManageEvidenceNotes/Overview/ViewAllOtherEvidenceOverview.cshtml
+++ b/src/EA.Weee.Web/Areas/Aatf/Views/ManageEvidenceNotes/Overview/ViewAllOtherEvidenceOverview.cshtml
@@ -16,7 +16,7 @@
                     @using (Html.BeginForm("Index", "ManageEvidenceNotes", FormMethod.Get))
                     {
                         @Html.Gds().ValidationSummary()
-                        @Html.Hidden("tab", Model.ActiveOverviewDisplayOption)
+                        @Html.Hidden("tab3", Model.ActiveOverviewDisplayOption)
                         @Html.Hidden("ManageEvidenceNoteViewModel.SelectedComplianceYear", Model.ManageEvidenceNoteViewModel.SelectedComplianceYear)
                         <div class="govuk-!-width-full govuk-panel-grey-background govuk-!-padding-bottom-0 govuk-!-margin-bottom-0">
 


### PR DESCRIPTION
there were 2 input elements with same id="tab" on AATF manage evidence notes tabs.
