### PR TITLE
49532 Make headings consistent for "date submitted" between various column headings

### DIFF
--- a/src/EA.Weee.Web.Tests.Unit/ViewModels/EvidenceNoteViewModelTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/ViewModels/EvidenceNoteViewModelTests.cs
@@ -42,7 +42,7 @@
         [InlineData("EndDate", "End date")]
         [InlineData("WasteTypeValue", "Obligation type")]
         [InlineData("ProtocolValue", "Actual or protocol")]
-        [InlineData("SubmittedDate", "Date submitted")]
+        [InlineData("SubmittedDate", "Submitted date")]
         [InlineData("RejectedDate", "Date rejected")]
         [InlineData("ReturnedDate", "Date returned")]
         [InlineData("ApprovedDate", "Date approved")]

--- a/src/EA.Weee.Web/Areas/Admin/Views/ManageEvidenceNotes/ViewAllEvidenceNotes.cshtml
+++ b/src/EA.Weee.Web/Areas/Admin/Views/ManageEvidenceNotes/ViewAllEvidenceNotes.cshtml
@@ -57,7 +57,7 @@
                                     Reference ID
                                 </th>
                                 <th class="govuk-table__header" scope="col">
-                                    Date submitted
+                                    Submitted date
                                 </th>
                                 <th class="govuk-table__header" style="vertical-align: bottom;" scope="col">
                                     Submitted by

--- a/src/EA.Weee.Web/Areas/Admin/Views/ManageEvidenceNotes/ViewAllTransferNotes.cshtml
+++ b/src/EA.Weee.Web/Areas/Admin/Views/ManageEvidenceNotes/ViewAllTransferNotes.cshtml
@@ -31,7 +31,7 @@
                                     Reference ID
                                 </th>
                                 <th class="govuk-table__header" scope="col" style="vertical-align: bottom;">
-                                    Date submitted
+                                    Submitted date
                                 </th>
                                 <th class="govuk-table__header" scope="col" style="vertical-align: bottom;">
                                     Submitted by

--- a/src/EA.Weee.Web/Areas/Scheme/Views/ManageEvidenceNotes/OutgoingTransfers.cshtml
+++ b/src/EA.Weee.Web/Areas/Scheme/Views/ManageEvidenceNotes/OutgoingTransfers.cshtml
@@ -24,7 +24,7 @@
                                 Reference ID
                             </th>
                             <th class="govuk-table__header govuk-!-text-align-left" scope="col">
-                                Date submitted
+                                Submitted date
                             </th>
                             <th class="govuk-table__header govuk-!-text-align-left" scope="col">
                                 Recipient

--- a/src/EA.Weee.Web/ViewModels/Shared/EvidenceNoteViewModel.cs
+++ b/src/EA.Weee.Web/ViewModels/Shared/EvidenceNoteViewModel.cs
@@ -33,7 +33,7 @@
         [DisplayName("Actual or protocol")]
         public virtual Protocol? ProtocolValue { get; set; }
 
-        [DisplayName("Date submitted")]
+        [DisplayName("Submitted date")]
         public string SubmittedDate { get; set; }
 
         [DisplayName("Date rejected")]

--- a/src/EA.Weee.Web/Views/Shared/_EvidenceTransferProgressiveDisclosurePartial.cshtml
+++ b/src/EA.Weee.Web/Views/Shared/_EvidenceTransferProgressiveDisclosurePartial.cshtml
@@ -7,7 +7,7 @@
     <thead class="govuk-table__head">
         <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header govuk-!-text-align-left">Reference ID</th>
-            <th scope="col" class="govuk-table__header govuk-!-text-align-left">Date submitted</th>
+            <th scope="col" class="govuk-table__header govuk-!-text-align-left">Submitted date</th>
             <th scope="col" class="govuk-table__header govuk-!-text-align-left">Transferred to</th>
             <th scope="col" class="govuk-table__header govuk-!-text-align-left">Status</th>
             <th scope="col" class="govuk-table__header govuk-!-text-align-left">@Html.Gds().VisuallyHidden("actions")</th>


### PR DESCRIPTION
modified 'Date submitted' to 'Submitted date' wherever applicable (not applied to reports)