### PR TITLE
Update OMPs Charges inline with consultation output

### DIFF
--- a/src/EA.Weee.Xml.Tests.Unit/MemberRegistration/EnvironmentAgencyProducerChargeBandCalculatorTests.cs
+++ b/src/EA.Weee.Xml.Tests.Unit/MemberRegistration/EnvironmentAgencyProducerChargeBandCalculatorTests.cs
@@ -361,6 +361,55 @@
             A.CallTo(() => fetchProducerCharge.GetCharge(ChargeBand.C)).MustHaveHappened(1, Times.Exactly);
         }
 
+        [Fact]
+        public async Task GetProducerChargeBand_OnlineMarketplace_UKEngland_AppliesAdditionalFee()
+        {
+            // Arrange
+            var countryType = new countryType();
+            countryType = countryType.UKENGLAND;
+            var eeePlacedOnMarketBandType = new eeePlacedOnMarketBandType();
+            eeePlacedOnMarketBandType = eeePlacedOnMarketBandType.Morethanorequalto5TEEEplacedonmarket;
+
+            var annualTurnoverBandType = new annualTurnoverBandType();
+            annualTurnoverBandType = annualTurnoverBandType.Greaterthanonemillionpounds;
+            var producerCharge = new ProducerCharge { Amount = 100m };
+
+            var producer = SetUpProducer(countryType, eeePlacedOnMarketBandType, annualTurnoverBandType, true);
+            producer.sellingTechnique = sellingTechniqueType.OnlineMarketplace;
+            A.CallTo(() => fetchProducerCharge.GetCharge(A<ChargeBand>._)).Returns(producerCharge);
+
+            // Act
+            var result = await environmentAgencyProducerChargeBandCalculator.GetProducerChargeBand(A.Dummy<schemeType>(), producer);
+
+            // Assert
+            Assert.Equal(100m + 13631m, result.Amount);
+        }
+
+        [Fact]
+        public async Task GetProducerChargeBand_OnlineMarketplace_NonUK_AppliesAdditionalFee()
+        {
+            // Arrange
+            var countryType = new countryType();
+            countryType = countryType.FRANCE;
+
+            var eeePlacedOnMarketBandType = new eeePlacedOnMarketBandType();
+            eeePlacedOnMarketBandType = eeePlacedOnMarketBandType.Morethanorequalto5TEEEplacedonmarket;
+
+            var annualTurnoverBandType = new annualTurnoverBandType();
+            annualTurnoverBandType = annualTurnoverBandType.Greaterthanonemillionpounds;
+            var producerCharge = new ProducerCharge { Amount = 200m };
+
+            var producer = SetUpProducer(countryType, eeePlacedOnMarketBandType, annualTurnoverBandType, true);
+            producer.sellingTechnique = sellingTechniqueType.OnlineMarketplace;
+            A.CallTo(() => fetchProducerCharge.GetCharge(A<ChargeBand>._)).Returns(producerCharge);
+
+            // Act
+            var result = await environmentAgencyProducerChargeBandCalculator.GetProducerChargeBand(A.Dummy<schemeType>(), producer);
+
+            // Assert
+            Assert.Equal(200m + 13631m, result.Amount);
+        }
+
         [Theory]
         [InlineData("2018")]
         [InlineData("2017")]

--- a/src/EA.Weee.Xml/MemberRegistration/EnvironmentAgencyProducerChargeBandCalculator.cs
+++ b/src/EA.Weee.Xml/MemberRegistration/EnvironmentAgencyProducerChargeBandCalculator.cs
@@ -88,7 +88,21 @@
                 }
             }
 
-            return await fetchProducerCharge.GetCharge(band);
+            var charge = await fetchProducerCharge.GetCharge(band);
+
+            // Apply additional fee for Online Marketplace for UK-England and Non-UK and has sellingTechnique of ‘Online marketplace’
+            bool isOnlineMarketplace = producer.sellingTechnique == sellingTechniqueType.OnlineMarketplace;
+            bool isEngland = producerCountry == countryType.UKENGLAND;
+            bool isNonUK = producerCountry != countryType.UKENGLAND &&
+                           producerCountry != countryType.UKSCOTLAND &&
+                           producerCountry != countryType.UKWALES &&
+                           producerCountry != countryType.UKNORTHERNIRELAND;
+            if (isOnlineMarketplace && (isEngland || isNonUK))
+            {
+                charge.Amount += 13631.00m; // Hard coded for now. 
+            }
+
+            return charge;
         }
 
         public bool IsMatch(schemeType scheme, producerType producer)


### PR DESCRIPTION
For scheme members with registeredOffice or principalPlaceOfBusiness in ‘UK-England’ or ‘Any other Non-UK’, with sellingTechnique as ‘Online marketplace’ then an additional fee of £13,631 needs to be applied. (i.e. calculated charge band fee + £13,631). See highlighted section in attachment.

29/07/25 update:   the English additional fee for OMP registration is confirmed as being £13,631.

In connection to the recent development work for WEEE Online in relation to OMPs, the activities relating to English data, need to be configured with the agreed charge fee following the current consultation process.